### PR TITLE
[FEAT] 디테일 페이지 컴포넌트 삽입

### DIFF
--- a/src/components/detail/PerformanceDetails.jsx
+++ b/src/components/detail/PerformanceDetails.jsx
@@ -76,7 +76,7 @@ function PerformanceDetails({data, score}) {
       <Content>
         {activeTab === 'details' && <Performance data={data}/>}
         {activeTab === 'cast' && <Casts />}
-        {activeTab === 'view-guide' && <Seats />}
+        {activeTab === 'view-guide' && <Seats musicalId={musicalId} />}
         {activeTab === 'reviews' && <Review musicalName={data.result.name} score={score}/>}
       </Content>
     </div>

--- a/src/components/eventcheck/MusicalEvent.jsx
+++ b/src/components/eventcheck/MusicalEvent.jsx
@@ -31,24 +31,24 @@ const MusicalEvent = (props) => {
 
 
     const addLike = async () => {
-        setIsLike(true); // UI 즉시 반영
+        setIsLike(true);
         try {
             await fetchData(`/musicals/${props.id}/likes`, "POST", { musicalId: props.id });
             console.log(props.id, "좋아요 등록");
         } catch (error) {
             console.error("좋아요 등록 실패:", error);
-            setIsLike(false); // 오류 발생 시 원래 상태로 복구
+            setIsLike(false);
         }
     };
 
     const cancelLike = async () => {
-        setIsLike(false); // UI 즉시 반영
+        setIsLike(false);
         try {
             await fetchData(`/musicals/${props.id}/likesCancel`, "DELETE", { musicalId: props.id });
             console.log(props.id, "좋아요 취소");
         } catch (error) {
             console.error("좋아요 취소 실패:", error);
-            setIsLike(true); // 오류 발생 시 원래 상태로 복구
+            setIsLike(true);
         }
     };
 

--- a/src/components/vision/detail/SearchBarDetail.jsx
+++ b/src/components/vision/detail/SearchBarDetail.jsx
@@ -98,6 +98,8 @@ const Overlay = styled.div`
 
 const SearchWrapper = styled.div`
     position: relative;
+    left: 100px;
+    
     width: 508px;
     z-index: 1000;
   `

--- a/src/components/vision/detail/TheatereInfo.jsx
+++ b/src/components/vision/detail/TheatereInfo.jsx
@@ -1,8 +1,10 @@
 import styled from "styled-components"
 import location from '../../../assets/icons/location.svg';
 import ChevronRight from '../../../assets/icons/ChevronRight.svg';
+import { useNavigate } from "react-router-dom";
 
 const TheatreInfo = (props) => {
+    const navigate = useNavigate();
     return (
         <Container>
             <TheaterInfo>
@@ -10,10 +12,13 @@ const TheatreInfo = (props) => {
 
                 <h3 className="title-B">{props?.data?.theatreName}</h3>
                 <p className="body-M-500">{props?.data?.address}</p>
-                <div className="NowShowing">
-                    <p className="body-M-400">현재 공연 <span className="ShowTitle">{props?.data?.musicalName}</span></p>
-                    <img src={ChevronRight} />
-                </div>
+
+                <Text>
+                    <p className="body-M-400">현재 공연</p>
+                    <span className="ShowTitle"
+                    onClick={()=>{navigate(`/detail/${props?.data?.musicalId}`)}}>{props?.data?.musicalName}
+                    <img src={ChevronRight} /></span>
+                </Text>
                 <hr className="hr-line" />
             </TheaterInfo>
         </Container>
@@ -29,16 +34,7 @@ const TheaterInfo = styled.div`
     h3{margin:0px;}
     p{margin: 0px;}
 
-    .NowShowing{
-        margin-top:25px;
-        display: flex;
-        align-items: center;
-    }
-    .ShowTitle{
-        font-size: 16px;
-        font-weight: 700;
-        color: #000000;      
-    }
+ 
     .hr-line{
         border : 0px;
         border-top: 1px solid #E6E6E6;
@@ -48,17 +44,35 @@ const TheaterInfo = styled.div`
         font-size: 24px;
         font-weight: 700;
     }
-    .body-M-400{
-        font-size: 16px;
-        font-weight: 500;
-        color: #919191;
-    }
+
     .body-M-500{
         font-size: 16px;
         font-weight: 500;
         color: #000000;
     }
 
+`
+const Text = styled.div`
+    margin-top:25px;
+    
+    display: flex;
+    align-items: center;
+    gap: 12px;
+
+    .body-M-400{
+        font-size: 16px;
+        font-weight: 500;
+        color: #919191;
+    }
+
+    .ShowTitle{
+        font-size: 16px;
+        font-weight: 700;
+        color: #000000;
+        
+        display: flex;
+        align-items: center;
+    }
 `
 
 export default TheatreInfo;

--- a/src/pages/EventDetail.jsx
+++ b/src/pages/EventDetail.jsx
@@ -13,6 +13,7 @@ function EventDetail() {
 
   const { data: musicalEvents } = useCustomFetch(`/events/${musicalId}`);
   const { data: musicals } = useCustomFetch(`/musicals/${musicalId}`);
+  console.log(musicalEvents);
 
   const handleDateSelect = (date) => {
       setSelectedDate(date);
@@ -32,7 +33,7 @@ function EventDetail() {
                   <h3 className="title-B-600">{musicalEvents?.result?.musicalName}</h3>
                   <img src={ChevronRight} className="ChevronRight" />
               </div>
-              <p className="body-M-600">{musicalEvents?.result?.theatreName}</p>
+              <p className="body-M-600">{musicalEvents?.result?.place}</p>
               <p className="body-M-500">{formatDate(musicalEvents?.result?.perFrom)} ~ {formatDate(musicalEvents?.result?.perTo)}</p>
               <img src={musicals?.result?.posterUrl} className="Poster" />
           </MusicalInfo>

--- a/src/pages/VisionDetail.jsx
+++ b/src/pages/VisionDetail.jsx
@@ -1,15 +1,18 @@
 import VisionDetailCL from "./vision/VisionDetailLotte";
 import VisionDetailBS from "./vision/VisionDetailBlueSquare";
+import SearchBarDetail from "../components/vision/detail/SearchBarDetail";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 
-const VisionDetailMain = () => {
-    const { theatreId } = useParams();
+const VisionDetailMain = ({theatreId}) => {
+    //const { theatreId } = useParams();
     const id = Number(theatreId);
     return(
         <Container>
-            {id === 1 && <VisionDetailBS/>}
-            {id === 7 && <VisionDetailCL/>}        
+            <SearchBarDetail/>
+
+            {id === 1 && <VisionDetailBS theatreId={1}/>}
+            {id === 7 && <VisionDetailCL theatreId={7}/>}        
         </Container>
     )
 }

--- a/src/pages/detail/MainContent.jsx
+++ b/src/pages/detail/MainContent.jsx
@@ -2,15 +2,30 @@ import React from "react";
 import styled from "styled-components";
 import PerformanceDetails from "../../components/detail/PerformanceDetails";
 import Info from "../../components/detail/Info";
-import Calendar from "../../components/Calendar";
+import Calendar from "../../components/Calendar2";
+import EventContent from "../../components/eventcheck/EventContent";
 import { RatingStars } from './../../components/detail/RatingStars';
 import ChevronRight from "../../assets/icons/ChevronRight.svg";
 import { useState } from "react";
 import HeartButton from "../../components/HeartButton";
 import useMoveScroll from "../../hooks/useMoveScroll";
+import useFetch from "../../hooks/useFetch";
+import { useNavigate } from "react-router-dom";
+
+const token = localStorage.getItem("accessToken");
+
+
 function MainContent({data,loading, error}) {
+  const navigate = useNavigate();
   const [liked, setLiked] = useState(data?.result?.isLike);
-  console.log(data?.result?.isLike);
+  console.log(data?.result);
+
+  const { data: event} = useFetch(`/events/${data?.result?.id}`, {
+    headers: {
+      Authorization: token ? `Bearer ${token}` : "",
+    },
+  },);
+  //console.log("이벤트:", event?.result?.eventResultListDTO);
   
 
   if (loading) return <div>Loading...</div>;
@@ -72,18 +87,32 @@ function MainContent({data,loading, error}) {
         </LeftSection>
 
         <RightSection>
-          <CalendarWrapper>
-            <Calendar variant="compact"/>
-            <hr />
-            티켓 오픈 컴포넌트
+
+          <CalendarWrapper >
+            <div style={{ transform: "scale(0.5)", transformOrigin: "top left" }}>
+              <Calendar
+                  variant="compact"
+              />
+            </div>
+            {/*<hr />
+            티켓 오픈 컴포넌트*/}
           </CalendarWrapper>
-          {/*
-          <GroupPurchaseButton>공동 구매하기</GroupPurchaseButton>
-           */}
+
           <EventLink>
-          <Text>이벤트 확인하기</Text><img src={ChevronRight} />
+            {event?.result?.eventResultListDTO.map((musical)=>(
+              <EventContent
+                    key={musical.id}
+                    content={musical.name}
+                    startAt={musical.evFrom}
+                    finishAt={musical.evTo}
+                    duration={musical.duration}
+                    />
+              ))}
+
+            <Text onClick={() => navigate(`/event-check/${data?.result?.id}`)}>이벤트 확인하기<img src={ChevronRight} /></Text>
           </EventLink>
         </RightSection>
+
         </div>
       </Wrapper>
    </>
@@ -182,8 +211,9 @@ const GroupPurchaseButton = styled.button`
 
 const CalendarWrapper = styled.div`
   width: 300px;
-  border: 1px solid #E6E6E6;
+  height: 400px;
 
+  border: 1px solid #E6E6E6;
   
   hr {
     border: none;
@@ -193,18 +223,22 @@ const CalendarWrapper = styled.div`
   }
 `
 const Text = styled.div`
-color: #000;
+  color: #000;
 
-/* Body-me */
-font-family: Pretendard;
-font-size: 16px;
-font-style: normal;
-font-weight: 500;
-line-height: 25px; /* 156.25% */
+  display: flex;
+  align-items: center;
+  justify-self: right;
+
+  /* Body-me */
+  font-family: Pretendard;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 25px; /* 156.25% */
 `
 const EventLink = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   width: 100%;
   justify-content: flex-end;
   margin-top: 16px;

--- a/src/pages/detail/subpages/Seats.jsx
+++ b/src/pages/detail/subpages/Seats.jsx
@@ -1,14 +1,21 @@
 import React from "react";
 import styled from "styled-components";
+import VisionDetailMain from "../../VisionDetail";
+import VisionDetail from "../../vision/VisionDetailLotte";
 
-function Seats() {
+function Seats({musicalId}) {
+  console.log("좌석확인", musicalId)
 
   return (
-    <>
-    <h1>시야 확인</h1>
-   </>
+    <Container style={{ transform: "scale(0.7)", transformOrigin: "top left" }}>
+      <VisionDetailMain theatreId={musicalId}/>
+   </Container>
     
   );
-}
+};
+
+const Container = styled.div`
+
+`
 
 export default Seats;

--- a/src/pages/vision/VisionDetailBlueSquare.jsx
+++ b/src/pages/vision/VisionDetailBlueSquare.jsx
@@ -64,8 +64,8 @@ import {
 } from '../../assets/theaterSeat/blueSquare/bluesquareSeat';
 
 
-const VisionDetailBS = () => {
-    const { theatreId } = useParams();
+const VisionDetailBS = ({theatreId}) => {
+    //const { theatreId } = useParams();
     const { data: theatre, error, loading } = useCustomFetch(
         `/theatres/${theatreId}/sectionType?sectionType`
     );
@@ -174,7 +174,7 @@ const VisionDetailBS = () => {
             
             <DetailArea>
                 <div>
-                    <SearchBarDetail />
+                    {/*<SearchBarDetail />*/}
 
                     <SeatArea>
                         <div className="Stage">STAGE</div>
@@ -322,6 +322,7 @@ const DetailArea = styled.div`
 `
 const SeatArea = styled.div`
     width: 580px;
+    margin-top: 50px;
 
     .Stage{
         justify-self: center;

--- a/src/pages/vision/VisionDetailLotte.jsx
+++ b/src/pages/vision/VisionDetailLotte.jsx
@@ -45,8 +45,8 @@ import {
 } from "../../assets/theaterSeat/charlotte/charlotteSeat";
 
 
-const VisionDetail = () => {
-    const { theatreId } = useParams();
+const VisionDetail = ({theatreId}) => {
+    //const { theatreId } = useParams();
     const { data: theatre, error, loading } = useCustomFetch(
         `/theatres/${theatreId}/sectionType?sectionType`
     );
@@ -129,7 +129,7 @@ const VisionDetail = () => {
         <Container>
             <DetailArea>
                 <div>
-                    <SearchBarDetail />
+                    {/*<SearchBarDetail />*/}
 
                     <SeatArea>
                         <div className="Stage">STAGE</div>
@@ -269,6 +269,7 @@ const DetailArea = styled.div`
 `
 const SeatArea = styled.div`
     width: 580px;
+    margin-top: 50px;
 
     .Stage{
         justify-self: center;


### PR DESCRIPTION
**뮤지컬 디테일 페이지**
달력, 이벤트, 좌석표 컴포넌트 삽입
->기존에 있던 컴포넌트를 재활용한 것이라 transfrom: scale을 통해 사이즈 조절함 (추후 디자인 수정 필요)

**이벤트 페이지 / 시야확인 페이지**
디테일 페이지 연결 /  API 수정에 따른 코드 수정 / 컴포넌트 재사용에 따른 코드 수정